### PR TITLE
fixes bug with selecting an error that's in a tab that isn't visible yet.

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2736,6 +2736,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
     }
 
     int tabIndex = p.getTabIndex();
+    sketch.setCurrentCode(tabIndex);  // so we are looking at the right offsets below
     int lineNumber = p.getLineNumber();
     int lineStart = textarea.getLineStartOffset(lineNumber);
     int lineEnd = textarea.getLineStopOffset(lineNumber);


### PR DESCRIPTION
switching the sketch to the tab index that contains the error before we find which chars to highlight. (I left the tab-opening in the next highlight() call alone in case it's used on other use cases)

uh this is my first PR generated within IDEA and it's been a while so if something looks horribly wrong about how I'm git-ing this, let me know